### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Super Mario Bros Level 1
+[![Run on Repl.it](https://repl.it/badge/github/justinmeister/Mario-Level-1)](https://repl.it/github/justinmeister/Mario-Level-1)
 =============
 
 An attempt to recreate the first level of Super Mario Bros.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@BraedenHermance/Mario-Level-1).